### PR TITLE
Define custom events before and after page switch animations

### DIFF
--- a/jquery.onepage-scroll.js
+++ b/jquery.onepage-scroll.js
@@ -86,7 +86,7 @@
         paginationList = "";
     
     $.fn.transformPage = function(settings, pos) {
-      $(this).css({
+      $(this).addClass('onepage-transform').css({
         "-webkit-transform": "translate3d(0, " + pos + "%, 0)", 
         "-webkit-transition": "all " + settings.animationTime + "ms " + settings.easing,
         "-moz-transform": "translate3d(0, " + pos + "%, 0)", 
@@ -97,7 +97,15 @@
         "transition": "all " + settings.animationTime + "ms " + settings.easing
       });
     }
-    
+
+    el.on('transitionend webkitTransitionEnd oTransitionEnd MSTransitionEnd', function(ev){
+      if ($(this).is('.onepage-transform')) {
+        el.trigger('onepagescroll.animation.ends', {
+          originalEvent: ev
+        });
+      }
+    });
+
     $.fn.moveDown = function() {
       var el = $(this)
       index = $(settings.sectionContainer +".active").data("index");
@@ -121,6 +129,12 @@
         }
         pos = (index * 100) * -1;
         el.transformPage(settings, pos);
+        el.trigger('onepagescroll.animation.started', {
+          direction: 'down',
+          slide: index,
+          current: current,
+          next: next
+        });
       }
     }
     
@@ -148,6 +162,12 @@
         }
         pos = ((next.data("index") - 1) * 100) * -1;
         el.transformPage(settings, pos);
+        el.trigger('onepagescroll.animation.started', {
+          direction: 'up',
+          slide: index,
+          current: current,
+          next: next
+        });
       }
     }
     


### PR DESCRIPTION
After this commit we could define actions that run before or after changing the page.

``` javascript
var page_selector = ".main";
$(page_selector).onepage_scroll({...});
$(document)
  .on('onepagescroll.animation.started', page_selector, function(ev, data){
    console.group('onepagescroll.animation.started');
    console.log(ev);
    console.log(data);
    console.log(arguments);
    console.groupEnd('onepagescroll.animation.started');  
  })
  .on('onepagescroll.animation.ends', page_selector, function(ev){
    console.group('#page-wrapper animation end');
    console.log(ev);
    console.log(arguments);
    console.groupEnd('#page-wrapper animation end');
  });
```

And a second commit adds the keyboard navigation support too...
