### PR TITLE
Update jquery.onepage-scroll.js

### DIFF
--- a/jquery.onepage-scroll.js
+++ b/jquery.onepage-scroll.js
@@ -36,16 +36,19 @@
         $this.bind('touchstart', touchstart);
 
         function touchstart(event) {
+          event.preventDefault();
+          var isClickableElement = event.originalEvent.target.tagName.match(/a|input|button|textarea/i);
+          if (isClickableElement) return $(event.originalEvent.target).trigger('click').trigger("focus");
           var touches = event.originalEvent.touches;
           if (touches && touches.length) {
             startX = touches[0].pageX;
             startY = touches[0].pageY;
             $this.bind('touchmove', touchmove);
           }
-          event.preventDefault();
         }
 
         function touchmove(event) {
+          event.preventDefault();
           var touches = event.originalEvent.touches;
           if (touches && touches.length) {
             var deltaX = startX - touches[0].pageX;
@@ -67,7 +70,6 @@
               $this.unbind('touchmove', touchmove);
             }
           }
-          event.preventDefault();
         }
 
       });
@@ -253,5 +255,6 @@
   }
   
 }(window.jQuery);
+
 
 


### PR DESCRIPTION
adds the ability for elements on the page like anchors, input elements, textareas, and buttons to be clickable. Otherwise, the swipe movement would work on any element, not just the document. If you'd like form elements to be focusable, use this.
