### PR TITLE
Formatted options comments for readability

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,15 +31,22 @@ Container "Main" must be one level below the `body` tag in order to make it work
  
 ````javascript
 $(".main").onepage_scroll({
-   sectionContainer: "section", // sectionContainer accepts any kind of selector in case you don't want to use section
-   easing: "ease", // Easing options accepts the CSS3 easing animation such "ease", "linear", "ease-in", "ease-out", "ease-in-out", or even cubic bezier value such as "cubic-bezier(0.175, 0.885, 0.420, 1.310)"
-   animationTime: 1000, // AnimationTime let you define how long each section takes to animate
-   pagination: true, // You can either show or hide the pagination. Toggle true for show, false for hide.
-   updateURL: false, // Toggle this true if you want the URL to be updated automatically when the user scroll to each page.
-   beforeMove: function(index) {}, // This option accepts a callback function. The function will be called before the page moves.
-   afterMove: function(index) {}, // This option accepts a callback function. The function will be called after the page moves.
-   loop: false, // You can have the page loop back to the top/bottom when the user navigates at up/down on the first/last page.
-   responsiveFallback: false // You can fallback to normal page scroll by defining the width of the browser in which you want the responsive fallback to be triggered. For example, set this to 600 and whenever the browser's width is less than 600, the fallback will kick in.
+   sectionContainer: "section",    // Any kind of selector in case you don't want to use section
+   easing: "ease",                 // CSS3 easing animation such "ease", "linear", "ease-in", 
+                                   // "ease-out", "ease-in-out", or even cubic bezier value such
+                                   // as "cubic-bezier(0.175, 0.885, 0.420, 1.310)"
+   animationTime: 1000,            // How long each section takes to animate
+   pagination: true,               // Show or hide the pagination. True for show, false for hide.
+   updateURL: false,               // Toggle this true if you want the URL to be updated
+                                   // automatically when the user scroll to each page.
+   beforeMove: function(index) {}, // Callback function which is called before the page moves.
+   afterMove: function(index) {},  // Callback function which is called after the page moves.
+   loop: false,                    // You can have the page loop back to the top/bottom when the
+                                   // user navigates at up/down on the first/last page.
+   responsiveFallback: false       // Fallback to normal page scroll by defining the width of the
+                                   // browser in which you want the responsive fallback to be 
+                                   // triggered. For example, set this to 600 and whenever the 
+                                   // browser's width is less than 600, the fallback will kick in.
 });
 ````
 And that's it. Now, your website should work the same way Apple's iPhone 5S website does. You should be able to swipe up/down as well (thanks to [Eike Send](https://github.com/eikes) for his swipe events!) when viewing your website on mobile phones.


### PR DESCRIPTION
You no longer need to scroll horizontally to read the comments with GitHub's standard readme styles.
