### PR TITLE
Before/after move callback enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,23 +85,23 @@ This method allows you to move to the specified page index programatically.
 ## Callbacks
 You can use callbacks to perform actions before or after the page move.
 
-### beforeMove(next_page_index)
+### beforeMove(next_page_index, next_section_element)
 This callback gets called before the plugin performs its move.
 
 ````javascript
   $(".main").onepage_scroll({
-    beforeMove: function(index) {
+    beforeMove: function(index, next_el) {
       ...
     }
   });
 ````
 
-### afterMove(next_page_index)
+### afterMove(next_page_index, next_section_element)
 This callback gets called after the move animation was performed.
 
 ````javascript
   $(".main").onepage_scroll({
-    afterMove: function(index) {
+    afterMove: function(index, next_el) {
       ...
     }
   });

--- a/jquery.onepage-scroll.js
+++ b/jquery.onepage-scroll.js
@@ -90,8 +90,8 @@
         quietPeriod = 500,
         paginationList = "";
     
-    $.fn.transformPage = function(settings, pos, index) {
-      if (typeof settings.beforeMove == 'function') settings.beforeMove(index);
+    $.fn.transformPage = function(settings, pos, index, next_el) {
+      if (typeof settings.beforeMove == 'function') settings.beforeMove(index, next_el);
       $(this).css({
         "-webkit-transform": "translate3d(0, " + pos + "%, 0)", 
         "-webkit-transition": "all " + settings.animationTime + "ms " + settings.easing,
@@ -103,7 +103,7 @@
         "transition": "all " + settings.animationTime + "ms " + settings.easing
       });
       $(this).one('webkitTransitionEnd otransitionend oTransitionEnd msTransitionEnd transitionend', function(e) {
-        if (typeof settings.afterMove == 'function') settings.afterMove(index);
+        if (typeof settings.afterMove == 'function') settings.afterMove(index, next_el);
       });
     }
     
@@ -137,7 +137,7 @@
         var href = window.location.href.substr(0,window.location.href.indexOf('#')) + "#" + (index + 1);
         history.pushState( {}, document.title, href );
       }   
-      el.transformPage(settings, pos, next.data("index"));
+      el.transformPage(settings, pos, next.data("index"), next);
     }
     
     $.fn.moveUp = function() {
@@ -170,7 +170,7 @@
         var href = window.location.href.substr(0,window.location.href.indexOf('#')) + "#" + (index - 1);
         history.pushState( {}, document.title, href );
       }
-      el.transformPage(settings, pos, next.data("index"));
+      el.transformPage(settings, pos, next.data("index"), next);
     }
     
     $.fn.moveTo = function(page_index) {
@@ -190,7 +190,7 @@
             var href = window.location.href.substr(0,window.location.href.indexOf('#')) + "#" + (page_index - 1);
             history.pushState( {}, document.title, href );
         }
-        el.transformPage(settings, pos, page_index);
+        el.transformPage(settings, pos, page_index, next);
       }
     }
     


### PR DESCRIPTION
This builds off my last pull request (#104) to also pass the next element into the callbacks after the index.

Nothing _should_ break, since it's an extra argument at the end (yay javascript)

This is useful for preparing the next screen to be shown, where you may wish to select elements inside that section. Doing that with the index would require more code, plus it's already done in `onepage-scroll`, just not currently passed in.

I suppose the correct element could be selected by its `.selected` class with jQuery, it's just nice if it's already there.
