### PR TITLE
enable momentum scrolling on iOS when onepage-scroll is disabled

### DIFF
--- a/onepage-scroll.css
+++ b/onepage-scroll.css
@@ -69,7 +69,8 @@ body, .onepage-wrapper, html {
 }
 
 .disabled-onepage-scroll, .disabled-onepage-scroll .wrapper {
-  overflow: auto;
+  overflow: scroll;
+  -webkit-overflow-scrolling: touch;
 }
 
 .disabled-onepage-scroll .onepage-wrapper .section {


### PR DESCRIPTION
Momentum scrolling on iOS safari doesn't work when using this plugin's responsive fallback. This change fixes that and restores the expected scrolling behavior.
