### PR TITLE
disable moveDown on spacebar when target is 'a' or 'button'

### DIFF
--- a/jquery.onepage-scroll.js
+++ b/jquery.onepage-scroll.js
@@ -399,7 +399,7 @@
               if (tag != 'input' && tag != 'textarea') el.moveDown()
             break;
             case 32: //spacebar
-              if (tag != 'input' && tag != 'textarea') el.moveDown()
+              if (tag != 'input' && tag != 'textarea' && tag != 'a' && tag != 'button') el.moveDown()
             break;
             case 33: //pageg up
               if (tag != 'input' && tag != 'textarea') el.moveUp()


### PR DESCRIPTION
Some people use keyboard navigation, and the spacebar may be used to trigger a link or a button.
The page should not scroll down in this situation.
