### PR TITLE
Make the page number go between 1 and the last page number.

### DIFF
--- a/jquery.onepage-scroll.js
+++ b/jquery.onepage-scroll.js
@@ -150,7 +150,11 @@
       $("body").addClass("viewing-page-"+next.data("index"))
 
       if (history.replaceState && settings.updateURL == true) {
-        var href = window.location.href.substr(0,window.location.href.indexOf('#')) + "#" + (index + 1);
+        if(index == total){
+          var href = window.location.href.substr(0,window.location.href.indexOf('#')) + "#" + 1;
+        } else{ 
+          var href = window.location.href.substr(0,window.location.href.indexOf('#')) + "#" + (index + 1);
+        }
         history.pushState( {}, document.title, href );
       }
       el.transformPage(settings, pos, next.data("index"));
@@ -184,7 +188,11 @@
       $("body").addClass("viewing-page-"+next.data("index"))
 
       if (history.replaceState && settings.updateURL == true) {
-        var href = window.location.href.substr(0,window.location.href.indexOf('#')) + "#" + (index - 1);
+        if(index == 1){
+          var href = window.location.href.substr(0,window.location.href.indexOf('#')) + "#" + total;
+        } else{
+          var href = window.location.href.substr(0,window.location.href.indexOf('#')) + "#" + (index - 1);
+        }
         history.pushState( {}, document.title, href );
       }
       el.transformPage(settings, pos, next.data("index"));


### PR DESCRIPTION
When updateURL is true and you scroll from top page to bottom page or in reverse direction, it shows non-existent page number after the hash mark.
The page number should be existent.

For example, let's assume that total number of pages was 3.
When current page number is 1 and you scroll to previous page then the page number becomes 0.
It should be 3.
When current page number is 3 and you scroll to next page then the page number becomes 4.
It should be 1.