### PR TITLE
 Fix a problem with scrolling down

### DIFF
--- a/jquery.onepage-scroll.js
+++ b/jquery.onepage-scroll.js
@@ -269,6 +269,8 @@
             event.preventDefault();
             return;
         }
+	    
+	if (deltaOfInterest == 0) return;
 
         if (deltaOfInterest < 0) {
           el.moveDown()


### PR DESCRIPTION
At any scrolling the event of scrolling upwards works as delta = 0 falls under the condition
 if (deltaOfInterest < 0) {
          el.moveDown()
        } else {
          el.moveUp()
        }