### PR TITLE
docs: Fix simple typo, vulnerabiliry -> vulnerability

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ License: [Attribution-ShareAlike 4.0 International](http://creativecommons.org/l
 
 jQuery (1.9.0 or later)
 
-note: jQuery 1.9.0 or later is strongly recommended because using jQuery less than 1.8.3 and jquery.onepage-scroll.js together turns out to be a hash-based XSS vulnerabiliry.
+note: jQuery 1.9.0 or later is strongly recommended because using jQuery less than 1.8.3 and jquery.onepage-scroll.js together turns out to be a hash-based XSS vulnerability.
 
 see: http://jsfiddle.net/33WJx/
 


### PR DESCRIPTION
There is a small typo in README.md.

Should read `vulnerability` rather than `vulnerabiliry`.

